### PR TITLE
Fix/outbound refer and add app_env

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,9 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 app.use('/', webhooks);
 
+// Set up environment routes
+app.use('/', require('./lib/env-vars'));
+
 require('./lib/routes')({logger, makeService});
 
 server.listen(port, () => {

--- a/app_env.json
+++ b/app_env.json
@@ -1,0 +1,21 @@
+{
+  "/socket": {
+    "RETELL_TRUNK_NAME": {
+      "description": "The name of the Carrier you configured in jambonz towards Retell",
+      "type": "string"
+    },
+      "RETELL_SIP_CLIENT_USERNAME": {
+      "description": "The name of the Client you configured in jambonz for Retell",
+      "type": "string"
+    },
+      "PSTN_TRUNK_NAME": {
+      "description": "The 2 *CHARACTER* ISO-3166 Country Code for your phone number eg US, GB, ES, see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for values",
+      "type": "string"
+
+    },
+      "OVERRIDE_FROM_USER": {
+      "description": "Value to use for From header in outbound calls to PSTN, original From callerID sent by Retell will be added to a Diversion header, use when SIPGATE is your carrier",
+      "type": "string"
+
+    }
+  }}

--- a/app_env.json
+++ b/app_env.json
@@ -2,20 +2,28 @@
   "/socket": {
     "RETELL_TRUNK_NAME": {
       "description": "The name of the Carrier you configured in jambonz towards Retell",
-      "type": "string"
+      "type": "string",
+      "required" : true
     },
       "RETELL_SIP_CLIENT_USERNAME": {
       "description": "The name of the Client you configured in jambonz for Retell",
-      "type": "string"
+      "type": "string",
+      "required" : true
     },
       "PSTN_TRUNK_NAME": {
+      "description": "The name of the Carrier you configured in jambonz towards your SIP service provider",
+      "type": "string",
+      "required" : true
+    },
+    "DEFAULT_COUNTRY": {
       "description": "The 2 *CHARACTER* ISO-3166 Country Code for your phone number eg US, GB, ES, see https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 for values",
-      "type": "string"
-
+      "type": "string",
+      "enum" : ["", "AF","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ","BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BA","BW","BV","BR","IO","BN","BG","BF","BI","KH","CM","CA","CV","KY","CF","TD","CL","CN","CX","CC","CO","KM","CG","CD","CK","CR","CI","HR","CU","CY","CZ","DK","DJ","DM","DO","EC","EG","SV","GQ","ER","EE","ET","FK","FO","FJ","FI","FR","GF","PF","TF","GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GN","GW","GY","HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IL","IT","JM","JP","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY","LI","LT","LU","MO","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT","MX","FM","MD","MC","MN","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ","NI","NE","NG","NU","NF","MP","MK","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH","PN","PL","PT","PR","QA","RE","RO","RU","RW","SH","KN","LC","PM","VC","WS","SM","ST","SA","SN","SC","SL","SG","SK","SI","SB","SO","ZA","GS","ES","LK","SD","SR","SJ","SZ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK","TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU","VE","VN","VG","VI","WF","EH","YE","ZM","ZW","AX","BQ","CW","GG","IM","JE","ME","BL","MF","RS","SX","SS","XK"],
+      "required" : false
     },
       "OVERRIDE_FROM_USER": {
       "description": "Value to use for From header in outbound calls to PSTN, original From callerID sent by Retell will be added to a Diversion header, use when SIPGATE is your carrier",
-      "type": "string"
-
+      "type": "string",
+      "required" : false
     }
   }}

--- a/app_env.json
+++ b/app_env.json
@@ -1,5 +1,5 @@
 {
-  "/socket": {
+  "/retell": {
     "RETELL_TRUNK_NAME": {
       "description": "The name of the Carrier you configured in jambonz towards Retell",
       "type": "string",

--- a/lib/env-vars/index.js
+++ b/lib/env-vars/index.js
@@ -1,0 +1,4 @@
+const router = require('express').Router();
+
+router.use('/socket', require('./options-handler'));
+module.exports = router;

--- a/lib/env-vars/index.js
+++ b/lib/env-vars/index.js
@@ -1,4 +1,4 @@
 const router = require('express').Router();
 
-router.use('/socket', require('./options-handler'));
+router.use('/retell', require('./options-handler'));
 module.exports = router;

--- a/lib/env-vars/options-handler.js
+++ b/lib/env-vars/options-handler.js
@@ -1,0 +1,33 @@
+const router = require('express').Router();
+
+const path = require('path');
+const { validateAppConfig, getAppConfig } = require('@jambonz/node-client-ws');
+const appJsonPath = path.join(__dirname, '../../app_env.json');
+const appJson = require(appJsonPath);
+
+router.options('/', (req, res) => {
+  const {logger} = req.app.locals;
+  logger.info(`OPTIONS request received for path: ${req.baseUrl}`);
+
+  // First validate the app.json using SDK's validation
+  const validationResult = validateAppConfig(appJson);
+  if (!validationResult.isValid) {
+    logger.error({ errors: validationResult.errors }, 'app.json validation failed');
+    return res.status(500).json({
+      error: 'Invalid app.json configuration',
+      details: validationResult.errors
+    });
+  }
+
+  // Get the appropriate configuration using SDK's getAppConfig
+  const result = getAppConfig({ urlPath: req.baseUrl, appJsonPath });
+  if (!result.success) {
+    logger.error(result.error);
+    return res.status(500).json({ error: result.error });
+  }
+
+  logger.debug({ config: result.config }, 'Returning configuration');
+  res.json(result.config);
+});
+
+module.exports = router;

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,4 +1,5 @@
 module.exports = ({logger, makeService}) => {
   require('./retell')({logger, makeService});
+  //require('./adulting')({logger, makeService});
 };
 

--- a/lib/routes/retell.js
+++ b/lib/routes/retell.js
@@ -13,13 +13,16 @@ if (DEFAULT_COUNTRY){
   validateCountryCode(DEFAULT_COUNTRY);
 }
 
+const sessions= {}
 const service = ({logger, makeService}) => {
-  const svc = makeService({path: '/retell'});
+  const svc = makeService({path: '/socket'});
 
   svc.on('session:new', async(session) => {
+    sessions[session.call_sid] = session;
+
     session.locals = {logger: logger.child({call_sid: session.call_sid})};
     let {from, to, direction, call_sid} = session;
-    logger.info({session}, `new incoming call: ${session.call_sid}`);
+    logger.info(`new ${session.direction} call: ${session.call_sid}`);
 
     /* Send ping to keep alive websocket as some platforms timeout, 25sec as 30sec timeout is not uncommon */
     session.locals.keepAlive = setInterval(() => {
@@ -42,7 +45,8 @@ const service = ({logger, makeService}) => {
       .on('/refer', onRefer.bind(null, session))
       .on('close', onClose.bind(null, session))
       .on('error', onError.bind(null, session))
-      .on('/dialAction', onDialAction.bind(null, session));
+      .on('/dialAction', onDialAction.bind(null, session))
+      .on('/referComplete', onReferComplete.bind(null, session));
 
     try {
       let target;
@@ -61,28 +65,6 @@ const service = ({logger, makeService}) => {
           //headers["P-Preferred-Identity"] = `${from}@SIPGATE_DOMAIN`;
           from = OVERRIDE_FROM_USER;
         }
-      }
-      else if (useDialSipEndpointMethod) {
-        /* https://docs.retellai.com/make-calls/custom-telephony#method-2-dial-to-sip-endpoint */
-        const retell_call_id = await registerCall(logger, {
-          agent_id: process.env.RETELL_AGENT_ID,
-          from,
-          to,
-          direction,
-          call_sid,
-          retell_llm_dynamic_variables: {
-            /* https://docs.retellai.com/retell-llm/dynamic-variables#phone-calls-with-your-own-numbers-custom-twilio */
-            user_name: 'John Doe',
-            user_email: 'john@example.com'
-          }
-        });
-        logger.info({retell_call_id}, 'Call registered');
-        target = [
-          {
-            type: 'sip',
-            sipUri: `sip:${retell_call_id}@5t4n6j0wnrl.sip.livekit.cloud`
-          }
-        ];
       }
       else {
         /* https://docs.retellai.com/make-calls/custom-telephony#method-1-elastic-sip-trunking-recommended */
@@ -130,7 +112,8 @@ const onRefer = (session, evt) => {
   session
     .sip_refer({
       referTo: refer_details.refer_to_user,
-      referredBy: evt.to
+      referredBy: evt.to,
+      actionHook: "/referComplete"
     })
     .reply();
 };
@@ -138,7 +121,7 @@ const onRefer = (session, evt) => {
 const onClose = (session, code, reason) => {
   const {logger} = session.locals;
   clearInterval(session.locals.keepAlive); // remove keep alive
-  logger.info({session, code, reason}, `session ${session.call_sid} closed`);
+  logger.info({code, reason}, `session ${session.call_sid} closed`);
 };
 
 const onError = (session, err) => {
@@ -156,4 +139,12 @@ const onDialAction = (session, evt) => {
   }
 }
 
+const onReferComplete = (session, evt) => {
+  const {logger} = session.locals;
+  logger.info({evt}, 'REFER COMPLETE')
+  let parentSession = sessions[session.parent_call_sid]
+  parentSession
+  .hangup()
+  .send()
+}
 module.exports = service;

--- a/lib/routes/retell.js
+++ b/lib/routes/retell.js
@@ -1,7 +1,6 @@
-const assert = require('assert');
-const {registerCall, getE164, validateCountryCode} = require('../../lib/utils');
+const {getE164} = require('../../lib/utils');
 
-const sessions= {}
+const sessions = {};
 const service = ({logger, makeService}) => {
   const svc = makeService({path: '/socket'});
 
@@ -9,7 +8,7 @@ const service = ({logger, makeService}) => {
     sessions[session.call_sid] = session;
 
     session.locals = {logger: logger.child({call_sid: session.call_sid})};
-    let {from, to, direction, call_sid} = session;
+    let {from, to} = session;
     logger.info(`new ${session.direction} call: ${session.call_sid}`);
 
     /* Setup the env vars from the webhook or from process.env if not sent */
@@ -18,7 +17,7 @@ const service = ({logger, makeService}) => {
     const RETELL_TRUNK_NAME = session.env_vars.RETELL_TRUNK_NAME || process.env.RETELL_TRUNK_NAME;
     const DEFAULT_COUNTRY = session.env_vars.DEFAULT_COUNTRY || process.env.DEFAULT_COUNTRY || false;
     const OVERRIDE_FROM_USER =  session.env_vars.OVERRIDE_FROM_USER || process.env.OVERRIDE_FROM_USER | false;
-    
+
     /* Send ping to keep alive websocket as some platforms timeout, 25sec as 30sec timeout is not uncommon */
     session.locals.keepAlive = setInterval(() => {
       session.ws.ping();
@@ -47,7 +46,7 @@ const service = ({logger, makeService}) => {
 
     try {
       let target;
-      let headers = {}
+      const headers = {};
       if (outboundFromRetell) {
         /* call is coming from Retell, so we will forward it to the original dialed number on the PSTN trunk */
         target = [
@@ -63,15 +62,15 @@ const service = ({logger, makeService}) => {
         }
       }
       else { //Call is from Carrier send it to retell
-        /* https://docs.retellai.com/make-calls/custom-telephony#method-1-elastic-sip-trunking-recommended */
+        /* https://docs.retellai.com/deploy/custom-telephony#method-1-elastic-sip-trunking-recommended */
 
         /**
          * Note: below we are forwarding the incoming call to Retell using the same dialed number.
          * This presumes you have added this number to your Retell account.
          * If you added a different number, you can change the `to` variable.
          */
-        // If default country code is set then ensure to is in e.164 format 
-        const dest = DEFAULT_COUNTRY ? await getE164(to, DEFAULT_COUNTRY) : to   
+        // If default country code is set then ensure to is in e.164 format
+        const dest = DEFAULT_COUNTRY ? await getE164(to, DEFAULT_COUNTRY, logger) : to;
         target = [
           {
             type: 'phone',
@@ -110,7 +109,7 @@ const onRefer = (session, evt) => {
     .sip_refer({
       referTo: refer_details.refer_to_user,
       referredBy: evt.to,
-      actionHook: "/referComplete"
+      actionHook: '/referComplete'
     })
     .reply();
 };
@@ -134,21 +133,20 @@ const onDialAction = (session, evt) => {
       .sip_decline({status: evt.dial_sip_status})
       .reply();
   }
-}
+};
 
 /* When the refer completes if we have an adulted call scenario hangup the original A leg */
 const onReferComplete = (session, evt) => {
   const {logger} = session.locals;
-  logger.info({evt}, 'referComplete')
-  if (session.parent_call_sid){
-    logger.info(`Sending hangup to parent session ${session.parent_call_sid}`)
-    let parentSession = sessions[session.parent_call_sid]
+  logger.info({evt}, 'referComplete');
+  if (session.parent_call_sid) {
+    logger.info(`Sending hangup to parent session ${session.parent_call_sid}`);
+    const parentSession = sessions[session.parent_call_sid];
     parentSession
-    .hangup()
-    .send()
+      .hangup()
+      .send();
   } else {
-    logger.debug('No parent session')
+    logger.debug('No parent session');
   }
-  
-}
+};
 module.exports = service;

--- a/lib/routes/retell.js
+++ b/lib/routes/retell.js
@@ -1,17 +1,5 @@
-const useDialSipEndpointMethod = Number(process.env.USE_DIAL_SIP_ENDPOINT_METHOD) || 0;
 const assert = require('assert');
 const {registerCall, getE164, validateCountryCode} = require('../../lib/utils');
-const DEFAULT_COUNTRY = process.env.DEFAULT_COUNTRY || false;
-const OVERRIDE_FROM_USER = process.env.OVERRIDE_FROM_USER | false;
-
-assert.ok(useDialSipEndpointMethod === 1 || process.env.RETELL_TRUNK_NAME,
-  // eslint-disable-next-line max-len
-  'RETELL_TRUNK_NAME env required when using elastic sip trunking method; it must contain the name of the jambonz BYOC trunk that connects to retell');
-
-// IF a default country code has been set check its the right format,
-if (DEFAULT_COUNTRY){
-  validateCountryCode(DEFAULT_COUNTRY);
-}
 
 const sessions= {}
 const service = ({logger, makeService}) => {
@@ -24,23 +12,32 @@ const service = ({logger, makeService}) => {
     let {from, to, direction, call_sid} = session;
     logger.info(`new ${session.direction} call: ${session.call_sid}`);
 
+    /* Setup the env vars from the webhook or from process.env if not sent */
+    const PSTN_TRUNK_NAME = session.env_vars.PSTN_TRUNK_NAME || process.env.PSTN_TRUNK_NAME;
+    const RETELL_SIP_CLIENT_USERNAME = session.env_vars.RETELL_SIP_CLIENT_USERNAME || process.env.RETELL_SIP_CLIENT_USERNAME;
+    const RETELL_TRUNK_NAME = session.env_vars.RETELL_TRUNK_NAME || process.env.RETELL_TRUNK_NAME;
+    const DEFAULT_COUNTRY = session.env_vars.DEFAULT_COUNTRY || process.env.DEFAULT_COUNTRY || false;
+    const OVERRIDE_FROM_USER =  session.env_vars.OVERRIDE_FROM_USER || process.env.OVERRIDE_FROM_USER | false;
+    
     /* Send ping to keep alive websocket as some platforms timeout, 25sec as 30sec timeout is not uncommon */
     session.locals.keepAlive = setInterval(() => {
       session.ws.ping();
     }, 25000);
 
+    /* Determine Call direction */
     let outboundFromRetell = false;
     if (session.direction === 'inbound' &&
-      process.env.PSTN_TRUNK_NAME && process.env.RETELL_SIP_CLIENT_USERNAME &&
+      PSTN_TRUNK_NAME && RETELL_SIP_CLIENT_USERNAME &&
       session.sip.headers['X-Authenticated-User']) {
 
       /* check if the call is coming from Retell; i.e. using the sip credential we provisioned there */
       const username = session.sip.headers['X-Authenticated-User'].split('@')[0];
-      if (username === process.env.RETELL_SIP_CLIENT_USERNAME) {
+      if (username === RETELL_SIP_CLIENT_USERNAME) {
         logger.info(`call ${session.call_sid} is coming from Retell`);
         outboundFromRetell = true;
       }
     }
+
     session
       .on('/refer', onRefer.bind(null, session))
       .on('close', onClose.bind(null, session))
@@ -52,21 +49,20 @@ const service = ({logger, makeService}) => {
       let target;
       let headers = {}
       if (outboundFromRetell) {
-        /* call is coming from Retell, so we will forward it to the original dialed number */
+        /* call is coming from Retell, so we will forward it to the original dialed number on the PSTN trunk */
         target = [
           {
             type: 'phone',
             number: to,
-            trunk: process.env.PSTN_TRUNK_NAME
+            trunk: PSTN_TRUNK_NAME
           }
         ];
         /* Workaround for SIPGATE, put User ID as from and CLI in header */
         if (OVERRIDE_FROM_USER) {
-          //headers["P-Preferred-Identity"] = `${from}@SIPGATE_DOMAIN`;
           from = OVERRIDE_FROM_USER;
         }
       }
-      else {
+      else { //Call is from Carrier send it to retell
         /* https://docs.retellai.com/make-calls/custom-telephony#method-1-elastic-sip-trunking-recommended */
 
         /**
@@ -80,11 +76,11 @@ const service = ({logger, makeService}) => {
           {
             type: 'phone',
             number: dest,
-            trunk: process.env.RETELL_TRUNK_NAME
+            trunk: RETELL_TRUNK_NAME
           }
         ];
       }
-
+      // Now that we have the destination target, send the dial command to the session.
       session
         .dial({
           callerId: from,
@@ -104,6 +100,7 @@ const service = ({logger, makeService}) => {
   });
 };
 
+/* When the remote end sends a refer pass it on to the other leg */
 const onRefer = (session, evt) => {
   const {logger} = session.locals;
   const {refer_details} = evt;
@@ -139,12 +136,19 @@ const onDialAction = (session, evt) => {
   }
 }
 
+/* When the refer completes if we have an adulted call scenario hangup the original A leg */
 const onReferComplete = (session, evt) => {
   const {logger} = session.locals;
-  logger.info({evt}, 'REFER COMPLETE')
-  let parentSession = sessions[session.parent_call_sid]
-  parentSession
-  .hangup()
-  .send()
+  logger.info({evt}, 'referComplete')
+  if (session.parent_call_sid){
+    logger.info(`Sending hangup to parent session ${session.parent_call_sid}`)
+    let parentSession = sessions[session.parent_call_sid]
+    parentSession
+    .hangup()
+    .send()
+  } else {
+    logger.debug('No parent session')
+  }
+  
 }
 module.exports = service;

--- a/lib/routes/retell.js
+++ b/lib/routes/retell.js
@@ -2,7 +2,7 @@ const {getE164} = require('../../lib/utils');
 
 const sessions = {};
 const service = ({logger, makeService}) => {
-  const svc = makeService({path: '/socket'});
+  const svc = makeService({path: '/retell'});
 
   svc.on('session:new', async(session) => {
     sessions[session.call_sid] = session;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,70 +1,13 @@
-const {request} = require('undici');
-
 const PNF = require('google-libphonenumber').PhoneNumberFormat;
 const phoneUtil = require('google-libphonenumber').PhoneNumberUtil.getInstance();
 
-/**
- * https://docs.retellai.com/api-references/register-phone-call
- */
-const registerCall = async(logger, {
-  agent_id,
-  from,
-  to,
-  direction,
-  call_sid,
-  retell_llm_dynamic_variables
-}) => {
-
-  try {
-    const payload = {
-      agent_id,
-      from_number: from,
-      to_number: to,
-      metadata: {
-        from,
-        to,
-        direction,
-        call_sid,
-      },
-      retell_llm_dynamic_variables: retell_llm_dynamic_variables ? retell_llm_dynamic_variables : {}
-    };
-    const {statusCode, body} = await request('https://api.retellai.com/v2/register-phone-call', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.RETELL_API_KEY}`
-      },
-      body: JSON.stringify(payload)
-    });
-    const data = await body.json();
-    if (statusCode !== 201 || !data?.call_id) {
-      logger.error({statusCode, data}, 'Error registering call');
-      throw new Error(`Error registering call: ${data.error_message}`);
-    }
-    logger.info({call_id: data.call_id}, 'Call registered');
-    return data.call_id;
-  } catch (err) {
-    logger.error(err, 'Error registering call');
-    throw err;
+const getE164 = async(number, country, logger) => {
+  const n = phoneUtil.parseAndKeepRawInput(number, country);
+  if (!phoneUtil.isValidNumber(n)) {
+    logger.warn(`to: ${number} is not a valid phone number in ${country}`);
   }
+  return phoneUtil.format(n, PNF.E164); //.replace('+', '') //Strip the +
 };
 
-const getE164 = async(number, country) => {
-  const n = phoneUtil.parseAndKeepRawInput(number, country);
-  if (!phoneUtil.isValidNumber(n)){
-    logger.warn(`to: ${number} is not a valid phone number in ${country}`)
-  }
-  return phoneUtil.format(n, PNF.E164)//.replace('+', '') //Strip the +
-}
 
-const validateCountryCode= async(code) => {
-    // list created by https://www.npmjs.com/package/i18n-iso-countries but hard coded as they hardley ever change so avoids adding more dependencies
-    countries = ["AF","AL","DZ","AS","AD","AO","AI","AQ","AG","AR","AM","AW","AU","AT","AZ","BS","BH","BD","BB","BY","BE","BZ","BJ","BM","BT","BO","BA","BW","BV","BR","IO","BN","BG","BF","BI","KH","CM","CA","CV","KY","CF","TD","CL","CN","CX","CC","CO","KM","CG","CD","CK","CR","CI","HR","CU","CY","CZ","DK","DJ","DM","DO","EC","EG","SV","GQ","ER","EE","ET","FK","FO","FJ","FI","FR","GF","PF","TF","GA","GM","GE","DE","GH","GI","GR","GL","GD","GP","GU","GT","GN","GW","GY","HT","HM","VA","HN","HK","HU","IS","IN","ID","IR","IQ","IE","IL","IT","JM","JP","JO","KZ","KE","KI","KP","KR","KW","KG","LA","LV","LB","LS","LR","LY","LI","LT","LU","MO","MG","MW","MY","MV","ML","MT","MH","MQ","MR","MU","YT","MX","FM","MD","MC","MN","MS","MA","MZ","MM","NA","NR","NP","NL","NC","NZ","NI","NE","NG","NU","NF","MP","MK","NO","OM","PK","PW","PS","PA","PG","PY","PE","PH","PN","PL","PT","PR","QA","RE","RO","RU","RW","SH","KN","LC","PM","VC","WS","SM","ST","SA","SN","SC","SL","SG","SK","SI","SB","SO","ZA","GS","ES","LK","SD","SR","SJ","SZ","SE","CH","SY","TW","TJ","TZ","TH","TL","TG","TK","TO","TT","TN","TR","TM","TC","TV","UG","UA","AE","GB","US","UM","UY","UZ","VU","VE","VN","VG","VI","WF","EH","YE","ZM","ZW","AX","BQ","CW","GG","IM","JE","ME","BL","MF","RS","SX","SS","XK"]
-    if (countries.includes(code)){
-      return true
-  } else {
-      throw new Error('Invalid DEFAULT COUNTRY, must contain ISO-3166-1-alpha2 values')
-  }
-}
-
-module.exports = { registerCall, getE164, validateCountryCode };
+module.exports = { getE164 };

--- a/lib/webhooks/endpoints/inbound-webhook.js
+++ b/lib/webhooks/endpoints/inbound-webhook.js
@@ -7,8 +7,8 @@ router.post('/', (req, res) => {
   res.json({
     call_inbound: {
       dynamic_variables: {
-         user_name: 'John Doe',
-         user_email: 'john@example.com'
+        user_name: 'John Doe',
+        user_email: 'john@example.com'
       },
       metadata: {
         random_id: '12345'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "retell-sip-api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "retell-sip-api",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@jambonz/node-client-ws": "^0.1.57",
         "express": "^4.21.1",
         "google-libphonenumber": "^3.2.40",
-        "i18n-iso-countries": "^7.14.0",
         "pino": "^9.5.0",
         "undici": "^6.20.1"
       },
@@ -697,12 +696,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/diacritics": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
-      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==",
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1296,18 +1289,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/i18n-iso-countries": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-7.14.0.tgz",
-      "integrity": "sha512-nXHJZYtNrfsi1UQbyRqm3Gou431elgLjKl//CYlnBGt5aTWdRPH1PiS2T/p/n8Q8LnqYqzQJik3Q7mkwvLokeg==",
-      "license": "MIT",
-      "dependencies": {
-        "diacritics": "1.3.0"
-      },
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "retell-sip-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "retell-sip-api",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
-        "@jambonz/node-client-ws": "^0.1.57",
+        "@jambonz/node-client-ws": "^0.2.3",
         "express": "^4.21.1",
         "google-libphonenumber": "^3.2.40",
         "pino": "^9.5.0",
@@ -196,21 +196,45 @@
       }
     },
     "node_modules/@jambonz/node-client-ws": {
-      "version": "0.1.57",
-      "resolved": "https://registry.npmjs.org/@jambonz/node-client-ws/-/node-client-ws-0.1.57.tgz",
-      "integrity": "sha512-FEilau7PXzjRPcePDKAzyd9rtSDWxn549gSkGLCIASeP3bxts47R0r3EqCnknZqTZ3gDs4Q/XdTF3C/wMEFb7g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@jambonz/node-client-ws/-/node-client-ws-0.2.3.tgz",
+      "integrity": "sha512-FfxmrYtprbFOUXvUrTTFh72785Sa1iqhfgkfjwQCMKY1DyIiCFuqp8pMd09ppaO7X8H10fa0uixpljBiKrdN0Q==",
       "license": "MIT",
       "dependencies": {
-        "@jambonz/verb-specifications": "^0.0.83",
+        "@jambonz/verb-specifications": "^0.0.104",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "debug": "^4.3.4",
         "parseurl": "^1.3.3",
         "ws": "^8.18.0"
       }
     },
+    "node_modules/@jambonz/node-client-ws/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@jambonz/node-client-ws/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@jambonz/verb-specifications": {
-      "version": "0.0.83",
-      "resolved": "https://registry.npmjs.org/@jambonz/verb-specifications/-/verb-specifications-0.0.83.tgz",
-      "integrity": "sha512-3m1o3gnWw1yEwNfkZ6IIyUhdUqsQ3aWBNoWJHswe4udvVbEIxPHi+8jKGTJVF2vxddzwfOWp7RmMCV9RmKWzkw==",
+      "version": "0.0.104",
+      "resolved": "https://registry.npmjs.org/@jambonz/verb-specifications/-/verb-specifications-0.0.104.tgz",
+      "integrity": "sha512-G1LjK6ISujdg0zALudtUvdaPXmvA4FU6x3s8S9MwUbWbFo2WERMUcNOgQAutDZwOMrLH9DnbPL8ZIdnTCKnlkA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -357,6 +381,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1011,9 +1074,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -1038,6 +1099,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -1852,9 +1929,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -1874,6 +1951,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "@jambonz/node-client-ws": "^0.2.3",
     "express": "^4.21.1",
     "google-libphonenumber": "^3.2.40",
-    "pino": "^9.5.0",
-    "undici": "^6.20.1"
+    "pino": "^9.5.0"
   },
   "devDependencies": {
     "eslint-plugin-promise": "^6.2.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@jambonz/node-client-ws": "^0.1.57",
+    "@jambonz/node-client-ws": "^0.2.3",
     "express": "^4.21.1",
     "google-libphonenumber": "^3.2.40",
     "pino": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retell-sip-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "jambonz websocket application",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Did a bit of an overhaul on the app:

- Have fixed the issue with an outbound call that then sends a refer leaving the A leg hanging, fixes #22 
- Added support for app_env variables, if these are not sent it will fallback to using the process.env var
- Have removed the other method of conneting to retell so now we always use the reccomended method 1 and we don't need to setup retell api keys or anything.
- Bumped version number
- Cleanup and linting
